### PR TITLE
Add allow_skip attribute to task group

### DIFF
--- a/ceryle/tasks/resolver.py
+++ b/ceryle/tasks/resolver.py
@@ -68,9 +68,10 @@ class DependencyChain:
 
     def add_dependency(self, dep):
         util.assert_type(dep, DependencyChain)
-        if not dep.root.allow_skip or not self.depends_on(dep):
-            self._deps = [*self._deps, dep]
-            return True
+        if dep.root.name in self.root.dependencies:
+            if not dep.root.allow_skip or not self.depends_on(dep):
+                self._deps = [*self._deps, dep]
+                return True
         return False
 
     def depends_on(self, dep):

--- a/ceryle/tasks/resolver.py
+++ b/ceryle/tasks/resolver.py
@@ -68,7 +68,7 @@ class DependencyChain:
 
     def add_dependency(self, dep):
         util.assert_type(dep, DependencyChain)
-        if not self.depends_on(dep):
+        if not dep.root.allow_skip or not self.depends_on(dep):
             self._deps = [*self._deps, dep]
             return True
         return False

--- a/ceryle/tasks/runner.py
+++ b/ceryle/tasks/runner.py
@@ -14,14 +14,9 @@ logger = logging.getLogger(__name__)
 
 class TaskRunner:
     def __init__(self, task_groups):
-        util.assert_type(task_groups, list)
-        for g in task_groups:
-            util.assert_type(g, TaskGroup)
-
-        resolver = DependencyResolver(dict([(g.name, [*g.dependencies]) for g in task_groups]))
+        resolver = DependencyResolver(task_groups)
         resolver.validate()
         self._deps_chain_map = resolver.deps_chain_map()
-        self._groups = dict([(g.name, g) for g in task_groups])
         self._run_cache = None
         self._sw = util.StopWatch()
 
@@ -65,7 +60,7 @@ class TaskRunner:
 
         try:
             util.print_out(f'running task group {chain.task_name}', level=logging.INFO)
-            res, reg = self._run_group(self._groups[chain.task_name], dry_run=dry_run, register=reg or register)
+            res, reg = self._run_group(chain.root, dry_run=dry_run, register=reg or register)
             self._sw.elapse()
             util.print_out(f'finished {chain.task_name} {self._sw.str_last_lap()}', level=logging.INFO)
         except Exception:

--- a/ceryle/tasks/runner.py
+++ b/ceryle/tasks/runner.py
@@ -45,7 +45,8 @@ class TaskRunner:
             if not res:
                 return False, reg
 
-        if self._run_cache.has(chain.task_name):
+        tg = chain.root
+        if tg.allow_skip and self._run_cache.has(chain.task_name):
             logger.info(f'skipping {chain} since it has already run')
             return True, register
 
@@ -60,7 +61,7 @@ class TaskRunner:
 
         try:
             util.print_out(f'running task group {chain.task_name}', level=logging.INFO)
-            res, reg = self._run_group(chain.root, dry_run=dry_run, register=reg or register)
+            res, reg = self._run_group(tg, dry_run=dry_run, register=reg or register)
             self._sw.elapse()
             util.print_out(f'finished {chain.task_name} {self._sw.str_last_lap()}', level=logging.INFO)
         except Exception:

--- a/ceryle/tasks/task.py
+++ b/ceryle/tasks/task.py
@@ -83,11 +83,12 @@ class Task:
 
 
 class TaskGroup:
-    def __init__(self, name, tasks, filename, dependencies=[]):
+    def __init__(self, name, tasks, filename, dependencies=[], allow_skip=True):
         self._name = util.assert_type(name, str)
         self._tasks = [util.assert_type(t, Task) for t in util.assert_type(tasks, list)]
         self._dependencies = [util.assert_type(d, str) for d in util.assert_type(dependencies, list)]
         self._filename = util.assert_type(filename, str)
+        self._allow_skip = util.assert_type(allow_skip, bool)
 
     @property
     def name(self):
@@ -100,6 +101,10 @@ class TaskGroup:
     @property
     def dependencies(self):
         return list(self._dependencies)
+
+    @property
+    def allow_skip(self):
+        return self._allow_skip
 
     @property
     def filename(self):

--- a/tests/dsl/dsl_spec
+++ b/tests/dsl/dsl_spec
@@ -103,6 +103,13 @@ default = 'foo'
         'conditional_on': condition.fail(command('test 1')),
     }],
 
+    'task_group_attributes': {
+        'allow_skip': False,
+        'tasks': [
+            command('run always'),
+        ],
+    },
+
     'args': [{
         'run': command(['echo',
                         env('ENV1'),

--- a/tests/dsl/test_loader.py
+++ b/tests/dsl/test_loader.py
@@ -21,7 +21,13 @@ def test_load_task_file():
 
     tasks = dict([(g.name, g) for g in task_def.tasks])
     task_names = tasks.keys()
-    for name in ['foo', 'bar', 'simple', 'shorten', 'pipe', 'pipe2', 'task_attributes', 'args']:
+    task_groups = [
+        'foo', 'bar', 'simple', 'shorten',
+        'pipe', 'pipe2',
+        'task_attributes', 'task_group_attributes',
+        'args',
+    ]
+    for name in task_groups:
         assert name in task_names
         g = tasks[name]
         assert isinstance(g, TaskGroup)

--- a/tests/tasks/test_resolver.py
+++ b/tests/tasks/test_resolver.py
@@ -125,6 +125,31 @@ def test_add_dependency_already_depending():
     assert c2.deps == [c3]
 
 
+def test_add_dependency_of_skip_not_allowed():
+    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
+    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle', allow_skip=False))
+    c3 = DependencyChain(TaskGroup('t3', [], 'file1.ceryle'))
+
+    assert c1.add_dependency(c2) is True
+    assert c1.add_dependency(c2) is True
+    assert c1.deps == [c2, c2]
+
+    assert c2.add_dependency(c3) is True
+    assert c1.add_dependency(c3) is False
+    assert c1.deps == [c2, c2]
+    assert c2.deps == [c3]
+
+    c4 = DependencyChain(TaskGroup('t4', [], 'file1.ceryle'))
+    c5 = DependencyChain(TaskGroup('t5', [], 'file1.ceryle'))
+    c6 = DependencyChain(TaskGroup('t6', [], 'file1.ceryle', allow_skip=False))
+
+    assert c4.add_dependency(c5) is True
+    assert c5.add_dependency(c6) is True
+    assert c4.add_dependency(c6) is True
+    assert c4.deps == [c5, c6]
+    assert c5.deps == [c6]
+
+
 def test_get_chain():
     c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
     c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle'))

--- a/tests/tasks/test_resolver.py
+++ b/tests/tasks/test_resolver.py
@@ -99,7 +99,7 @@ def test_new_dependency_chain():
 
 
 def test_add_dependency_added():
-    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
+    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle', dependencies=['t2', 't3']))
     c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle'))
     c3 = DependencyChain(TaskGroup('t3', [], 'file1.ceryle'))
 
@@ -111,8 +111,8 @@ def test_add_dependency_added():
 
 
 def test_add_dependency_already_depending():
-    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
-    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle'))
+    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle', dependencies=['t2', 't3']))
+    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle', dependencies=['t3']))
     c3 = DependencyChain(TaskGroup('t3', [], 'file1.ceryle'))
 
     assert c1.add_dependency(c2) is True
@@ -125,9 +125,16 @@ def test_add_dependency_already_depending():
     assert c2.deps == [c3]
 
 
-def test_add_dependency_of_skip_not_allowed():
+def test_add_dependency_but_not_depending():
     c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
-    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle', allow_skip=False))
+    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle'))
+
+    assert c1.add_dependency(c2) is False
+
+
+def test_add_dependency_of_skip_not_allowed():
+    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle', dependencies=['t2', 't2', 't3']))
+    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle', dependencies=['t3'], allow_skip=False))
     c3 = DependencyChain(TaskGroup('t3', [], 'file1.ceryle'))
 
     assert c1.add_dependency(c2) is True
@@ -139,8 +146,8 @@ def test_add_dependency_of_skip_not_allowed():
     assert c1.deps == [c2, c2]
     assert c2.deps == [c3]
 
-    c4 = DependencyChain(TaskGroup('t4', [], 'file1.ceryle'))
-    c5 = DependencyChain(TaskGroup('t5', [], 'file1.ceryle'))
+    c4 = DependencyChain(TaskGroup('t4', [], 'file1.ceryle', dependencies=['t5', 't6']))
+    c5 = DependencyChain(TaskGroup('t5', [], 'file1.ceryle', dependencies=['t6']))
     c6 = DependencyChain(TaskGroup('t6', [], 'file1.ceryle', allow_skip=False))
 
     assert c4.add_dependency(c5) is True
@@ -151,8 +158,8 @@ def test_add_dependency_of_skip_not_allowed():
 
 
 def test_get_chain():
-    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
-    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle'))
+    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle', dependencies=['t2']))
+    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle', dependencies=['t3']))
     c3 = DependencyChain(TaskGroup('t3', [], 'file1.ceryle'))
 
     assert c1.get_chain(c2) == []
@@ -178,13 +185,13 @@ def test_get_chain():
 
 
 def test_dependency_chain_equality():
-    c1a = DependencyChain(TaskGroup('t1', [], 'file1'))
-    c1b = DependencyChain(TaskGroup('t1', [], 'file1'))
+    c1a = DependencyChain(TaskGroup('t1', [], 'file1', dependencies=['t2']))
+    c1b = DependencyChain(TaskGroup('t1', [], 'file1', dependencies=['t2']))
 
     assert c1a == c1b
     assert not c1a != c1b
 
-    c1a.add_dependency(DependencyChain(TaskGroup('t2', [], 'file11')))
+    c1a.add_dependency(DependencyChain(TaskGroup('t2', [], 'file11.ceryle')))
 
     assert not c1a == c1b
     assert c1a != c1b
@@ -200,14 +207,14 @@ def test_dependency_chain_equality():
 
 def test_dump_chain():
 
-    a11 = DependencyChain(TaskGroup('t11', [], 'file11.ceryle'))
+    a11 = DependencyChain(TaskGroup('t11', [], 'file11.ceryle', dependencies=['t111', 't112']))
     a11.add_dependency(DependencyChain(TaskGroup('t111', [], 'file1.ceryle')))
     a11.add_dependency(DependencyChain(TaskGroup('t112', [], 'file1.ceryle')))
 
-    a12 = DependencyChain(TaskGroup('t12', [], 'file1.ceryle'))
+    a12 = DependencyChain(TaskGroup('t12', [], 'file1.ceryle', dependencies=['t121']))
     a12.add_dependency(DependencyChain(TaskGroup('t121', [], 'file1.ceryle')))
 
-    a1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
+    a1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle', dependencies=['t11', 't12']))
     a1.add_dependency(a11)
     a1.add_dependency(a12)
 

--- a/tests/tasks/test_resolver.py
+++ b/tests/tasks/test_resolver.py
@@ -1,44 +1,44 @@
 import pytest
 import re
 
-from ceryle import TaskDependencyError
-from ceryle.tasks.resolver import DependencyChain, DependencyResolver, dump_chain
+from ceryle import TaskGroup, TaskDependencyError, DependencyChain, DependencyResolver
+from ceryle.tasks.resolver import dump_chain
 
 
 def test_validate_fails_by_cyclic():
     with pytest.raises(TaskDependencyError) as e1:
-        resolver = DependencyResolver({
-            'a': ['a'],
-        })
+        resolver = DependencyResolver([
+            TaskGroup('a', [], 'file1.ceryle', dependencies=['a']),
+        ])
         resolver.validate()
     assert str(e1.value) == 'cyclic dependency was found: a -> a'
 
     with pytest.raises(TaskDependencyError) as e2:
-        resolver = DependencyResolver({
-            'a': ['b'],
-            'b': ['a'],
-        })
+        resolver = DependencyResolver([
+            TaskGroup('a', [], 'file1.ceryle', dependencies=['b']),
+            TaskGroup('b', [], 'file1.ceryle', dependencies=['a']),
+        ])
         resolver.validate()
     p2 = 'cyclic dependency was found: (a -> b -> a|b -> a -> b)'
     assert re.match(p2, str(e2.value))
 
     with pytest.raises(TaskDependencyError) as e3:
-        resolver = DependencyResolver({
-            'd': ['e'],
-            'e': ['f'],
-            'f': ['d'],
-        })
+        resolver = DependencyResolver([
+            TaskGroup('d', [], 'file1.ceryle', dependencies=['e']),
+            TaskGroup('e', [], 'file1.ceryle', dependencies=['f']),
+            TaskGroup('f', [], 'file1.ceryle', dependencies=['d']),
+        ])
         resolver.validate()
     p3 = 'cyclic dependency was found: (d -> e -> f -> d|e -> f -> d -> e|f -> d -> e -> f)'
     assert re.match(p3, str(e3.value))
 
     with pytest.raises(TaskDependencyError) as e4:
-        resolver = DependencyResolver({
-            'g': ['h'],
-            'h': ['i'],
-            'i': ['j'],
-            'j': ['h'],
-        })
+        resolver = DependencyResolver([
+            TaskGroup('g', [], 'file1.ceryle', dependencies=['h']),
+            TaskGroup('h', [], 'file1.ceryle', dependencies=['i']),
+            TaskGroup('i', [], 'file1.ceryle', dependencies=['j']),
+            TaskGroup('j', [], 'file1.ceryle', dependencies=['h']),
+        ])
         resolver.validate()
     p4 = 'cyclic dependency was found: (h -> i -> j -> h|i -> j -> h -> i|j -> h -> i -> j)'
     assert re.match(p4, str(e4.value))
@@ -46,18 +46,18 @@ def test_validate_fails_by_cyclic():
 
 def test_validate_fails_by_no_depnding_task():
     with pytest.raises(TaskDependencyError) as e:
-        resolver = DependencyResolver({
-            'a': ['b'],
-        })
+        resolver = DependencyResolver([
+            TaskGroup('a', [], 'file1.ceryle', dependencies=['b']),
+        ])
         resolver.validate()
     assert str(e.value) == 'task b depended by a is not defined'
 
 
 def test_consstruct_chain_map_no_dependency():
-    resolver = DependencyResolver({
-        'a': [],
-        'b': [],
-    })
+    resolver = DependencyResolver([
+        TaskGroup('a', [], 'file1.ceryle'),
+        TaskGroup('b', [], 'file1.ceryle'),
+    ])
     resolver.validate()
     chain_map = resolver.deps_chain_map()
 
@@ -67,22 +67,21 @@ def test_consstruct_chain_map_no_dependency():
 
 
 def test_construct_chain_map():
-    resolver = DependencyResolver({
-        'a': ['b', 'c'],
-        'b': ['c'],
-        'c': [],
-    })
+    tg_a = TaskGroup('a', [], 'file1.ceryle', dependencies=['b', 'c'])
+    tg_b = TaskGroup('b', [], 'file1.ceryle', dependencies=['c'])
+    tg_c = TaskGroup('c', [], 'file1.ceryle', dependencies=[])
+    resolver = DependencyResolver([tg_a, tg_b, tg_c])
     resolver.validate()
     chain_map = resolver.deps_chain_map()
 
     assert len(chain_map) == 3
 
-    chain_c = DependencyChain('c')
+    chain_c = DependencyChain(tg_c)
 
-    chain_b = DependencyChain('b')
+    chain_b = DependencyChain(tg_b)
     chain_b.add_dependency(chain_c)
 
-    chain_a = DependencyChain('a')
+    chain_a = DependencyChain(tg_a)
     chain_a.add_dependency(chain_b)
 
     assert chain_map['a'] == chain_a
@@ -91,16 +90,18 @@ def test_construct_chain_map():
 
 
 def test_new_dependency_chain():
-    c1 = DependencyChain('c1')
+    tg = TaskGroup('c1', [], 'file1.ceryle')
+    c1 = DependencyChain(tg)
 
+    assert c1.root == tg
     assert c1.task_name == 'c1'
     assert c1.deps == []
 
 
 def test_add_dependency_added():
-    c1 = DependencyChain('t1')
-    c2 = DependencyChain('t2')
-    c3 = DependencyChain('t3')
+    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
+    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle'))
+    c3 = DependencyChain(TaskGroup('t3', [], 'file1.ceryle'))
 
     assert c1.add_dependency(c2) is True
     assert c1.deps == [c2]
@@ -110,9 +111,9 @@ def test_add_dependency_added():
 
 
 def test_add_dependency_already_depending():
-    c1 = DependencyChain('t1')
-    c2 = DependencyChain('t2')
-    c3 = DependencyChain('t3')
+    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
+    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle'))
+    c3 = DependencyChain(TaskGroup('t3', [], 'file1.ceryle'))
 
     assert c1.add_dependency(c2) is True
     assert c1.add_dependency(c2) is False
@@ -125,9 +126,9 @@ def test_add_dependency_already_depending():
 
 
 def test_get_chain():
-    c1 = DependencyChain('t1')
-    c2 = DependencyChain('t2')
-    c3 = DependencyChain('t3')
+    c1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
+    c2 = DependencyChain(TaskGroup('t2', [], 'file1.ceryle'))
+    c3 = DependencyChain(TaskGroup('t3', [], 'file1.ceryle'))
 
     assert c1.get_chain(c2) == []
     assert c1.get_chain(c2, include_self=True) == [c1]
@@ -152,18 +153,18 @@ def test_get_chain():
 
 
 def test_dependency_chain_equality():
-    c1a = DependencyChain('t1')
-    c1b = DependencyChain('t1')
+    c1a = DependencyChain(TaskGroup('t1', [], 'file1'))
+    c1b = DependencyChain(TaskGroup('t1', [], 'file1'))
 
     assert c1a == c1b
     assert not c1a != c1b
 
-    c1a.add_dependency(DependencyChain('t2'))
+    c1a.add_dependency(DependencyChain(TaskGroup('t2', [], 'file11')))
 
     assert not c1a == c1b
     assert c1a != c1b
 
-    c1b.add_dependency(DependencyChain('t2'))
+    c1b.add_dependency(DependencyChain(TaskGroup('t2', [], 'file11.ceryle')))
 
     assert c1a == c1b
     assert not c1a != c1b
@@ -174,14 +175,14 @@ def test_dependency_chain_equality():
 
 def test_dump_chain():
 
-    a11 = DependencyChain('t11')
-    a11.add_dependency(DependencyChain('t111'))
-    a11.add_dependency(DependencyChain('t112'))
+    a11 = DependencyChain(TaskGroup('t11', [], 'file11.ceryle'))
+    a11.add_dependency(DependencyChain(TaskGroup('t111', [], 'file1.ceryle')))
+    a11.add_dependency(DependencyChain(TaskGroup('t112', [], 'file1.ceryle')))
 
-    a12 = DependencyChain('t12')
-    a12.add_dependency(DependencyChain('t121'))
+    a12 = DependencyChain(TaskGroup('t12', [], 'file1.ceryle'))
+    a12.add_dependency(DependencyChain(TaskGroup('t121', [], 'file1.ceryle')))
 
-    a1 = DependencyChain('t1')
+    a1 = DependencyChain(TaskGroup('t1', [], 'file1.ceryle'))
     a1.add_dependency(a11)
     a1.add_dependency(a12)
 

--- a/tests/tasks/test_runner.py
+++ b/tests/tasks/test_runner.py
@@ -390,6 +390,64 @@ def test_run_skip_task_already_run(mocker):
     assert cache.register == {}
 
 
+def test_run_do_not_skip_if_not_allowed(mocker):
+    mock = mocker.Mock()
+
+    g1_t1 = Task(Command('do some'), 'context')
+    g1 = TaskGroup('g1', [g1_t1], 'file1.ceryle', dependencies=['g2', 'g3', 'g4', 'g4'])
+
+    g2_t1 = Task(Command('do some'), 'context')
+    g2 = TaskGroup('g2', [g2_t1], 'file1.ceryle', dependencies=['g4'])
+
+    g3_t1 = Task(Command('do some'), 'context')
+    g3 = TaskGroup('g3', [g3_t1], 'file1.ceryle', dependencies=['g4'])
+
+    g4_t1 = Task(Command('do some'), 'context')
+    g4 = TaskGroup('g4', [g4_t1], 'file1.ceryle', dependencies=[], allow_skip=False)
+
+    g1_t1_run = mocker.patch.object(g1_t1, 'run', return_value=True)
+    mock.attach_mock(g1_t1_run, 'g1_t1_run')
+
+    g2_t1_run = mocker.patch.object(g2_t1, 'run', return_value=True)
+    mock.attach_mock(g2_t1_run, 'g2_t1_run')
+
+    g3_t1_run = mocker.patch.object(g3_t1, 'run', return_value=True)
+    mock.attach_mock(g3_t1_run, 'g3_t1_run')
+
+    g4_t1_run = mocker.patch.object(g4_t1, 'run', return_value=True)
+    mock.attach_mock(g4_t1_run, 'g4_t1_run')
+
+    runner = TaskRunner([g1, g2, g3, g4])
+
+    assert runner.run('g1') is True
+    assert g4_t1.run.call_count == 4
+    g2_t1.run.assert_called_once()
+    g3_t1.run.assert_called_once()
+    g1_t1.run.assert_called_once()
+    assert mock.mock_calls == [
+        mocker.call.g4_t1_run(dry_run=False, inputs=[]),
+        mocker.call.g2_t1_run(dry_run=False, inputs=[]),
+        mocker.call.g4_t1_run(dry_run=False, inputs=[]),
+        mocker.call.g3_t1_run(dry_run=False, inputs=[]),
+        mocker.call.g4_t1_run(dry_run=False, inputs=[]),
+        mocker.call.g4_t1_run(dry_run=False, inputs=[]),
+        mocker.call.g1_t1_run(dry_run=False, inputs=[]),
+    ]
+
+    cache = runner.get_cache()
+    assert cache.task_name == 'g1'
+    assert cache.results == [
+        ('g4', True),
+        ('g2', True),
+        ('g4', True),
+        ('g3', True),
+        ('g4', True),
+        ('g4', True),
+        ('g1', True),
+    ]
+    assert cache.register == {}
+
+
 def test_run_skip_succeeded_tasks(mocker):
     mock = mocker.Mock()
 


### PR DESCRIPTION
Some dependencies of task may be skipped if already run it at runtime by default.
If do NOT allow skip (run always), set `allow_skip` attribute of task group to `False`.